### PR TITLE
会員登録フォームへのテキスト追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,8 @@
   "prettier.configPath": "./prettierrc.js",
   "stylelint.configFile": "./.stylelintrc.js",
   "editor.codeActionsOnSave": {
-    "source.fixAll.stylelint": true,
-    "source.fixAll.eslint": true
+    "source.fixAll.stylelint": "explicit",
+    "source.fixAll.eslint": "explicit"
   },
   "editor.tabSize": 2
 }

--- a/src/public/signup.php
+++ b/src/public/signup.php
@@ -2,6 +2,7 @@
   <div>
     <div>
       <h2>会員登録</h2>
+      <p>- Sing up to continue -</p>
       <form action="./signup_complete.php" method="POST">
         <p><input placeholder="User name" type=“text” name="userName" required value=""></p>
         <p><input placeholder="Email" type=“mail” name="email" required value=""></p>

--- a/src/public/signup.php
+++ b/src/public/signup.php
@@ -2,7 +2,7 @@
   <div>
     <div>
       <h2>会員登録</h2>
-      <p>- Sing up to continue -</p>
+      <p>- Sign up to continue -</p>
       <form action="./signup_complete.php" method="POST">
         <p><input placeholder="User name" type=“text” name="userName" required value=""></p>
         <p><input placeholder="Email" type=“mail” name="email" required value=""></p>


### PR DESCRIPTION
会員登録フォームへ”Sign up to continue”　のテキストを追加しました。
機能はありません。
![スクリーンショット 2024-11-09 13 06 40](https://github.com/user-attachments/assets/992b205d-6b60-46c8-8692-8b150365c55c)
